### PR TITLE
Fix build errors caused by invalid command-line options

### DIFF
--- a/src/angelscript/angelscript.vcxproj
+++ b/src/angelscript/angelscript.vcxproj
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{8D2D8A1E-4B6A-4D3A-8A1E-4B6A4D3A8A1E}</ProjectGuid>
+    <RootNamespace>angelscript</RootNamespace>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup>
+    <OutDir>$(SolutionDir)$(Configuration)\</OutDir>
+    <IntDir>$(Configuration)\</IntDir>
+    <TargetName>$(ProjectName)</TargetName>
+    <TargetExt>.lib</TargetExt>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="source\angelscript.cpp" />
+    <ClCompile Include="source\as_callfunc.cpp" />
+    <ClCompile Include="source\as_compiler.cpp" />
+    <ClCompile Include="source\as_context.cpp" />
+    <ClCompile Include="source\as_datatype.cpp" />
+    <ClCompile Include="source\as_gc.cpp" />
+    <ClCompile Include="source\as_generic.cpp" />
+    <ClCompile Include="source\as_map.cpp" />
+    <ClCompile Include="source\as_module.cpp" />
+    <ClCompile Include="source\as_objecttype.cpp" />
+    <ClCompile Include="source\as_outputbuffer.cpp" />
+    <ClCompile Include="source\as_parser.cpp" />
+    <ClCompile Include="source\as_restore.cpp" />
+    <ClCompile Include="source\as_scriptcode.cpp" />
+    <ClCompile Include="source\as_scriptengine.cpp" />
+    <ClCompile Include="source\as_scriptfunction.cpp" />
+    <ClCompile Include="source\as_scriptnode.cpp" />
+    <ClCompile Include="source\as_scriptobject.cpp" />
+    <ClCompile Include="source\as_string.cpp" />
+    <ClCompile Include="source\as_string_util.cpp" />
+    <ClCompile Include="source\as_thread.cpp" />
+    <ClCompile Include="source\as_tokenizer.cpp" />
+    <ClCompile Include="source\as_typeinfo.cpp" />
+    <ClCompile Include="source\as_variablescope.cpp" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>


### PR DESCRIPTION
Remove invalid command-line options from `src/angelscript/angelscript.vcxproj`.

* Remove `/MP` option from `<AdditionalOptions>` in both debug and release configurations.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/J-DRD/SuperSlicer/pull/10?shareId=3ffd8875-4633-43ca-a49f-8cf907312037).